### PR TITLE
feat: add support for stream quality configuration via config file

### DIFF
--- a/mov_cli_youtube/__init__.py
+++ b/mov_cli_youtube/__init__.py
@@ -22,4 +22,4 @@ plugin: PluginHookData = {
     }
 }
 
-__version__ = "1.3.5"
+__version__ = "1.3.6"

--- a/mov_cli_youtube/yt_dlp.py
+++ b/mov_cli_youtube/yt_dlp.py
@@ -19,9 +19,9 @@ if TYPE_CHECKING:
 
 import yt_dlp
 
+from mov_cli import ExtraMetadata, Metadata, MetadataType, Quality, Single
 from mov_cli.scraper import Scraper
 from mov_cli.utils import EpisodeSelector
-from mov_cli import Single, Metadata, MetadataType, ExtraMetadata
 
 __all__ = ("YTDlpScraper",)
 
@@ -129,7 +129,7 @@ class YTDlpScraper(Scraper):
 
             if (
                 # Only filter when not "auto"
-                self.config.resolution.name != "AUTO"
+                self.config.resolution != Quality.AUTO
                 and stream_format.get("height")
                 and stream_format["height"] > self.config.resolution.value
             ):

--- a/mov_cli_youtube/yt_dlp.py
+++ b/mov_cli_youtube/yt_dlp.py
@@ -127,6 +127,14 @@ class YTDlpScraper(Scraper):
                 if ensure_correct_audio_localisation and not stream_format["language"] == self.config.language.iso639_1:
                     continue
 
+            if (
+                # Only filter when not "auto"
+                self.config.resolution.name != "AUTO"
+                and stream_format.get("height")
+                and stream_format["height"] > self.config.resolution.value
+            ):
+                continue
+
             url: str = stream_format["url"]
             quality: int = stream_format["quality"]
 


### PR DESCRIPTION
In this pull request, I have added the ability to set a preferred stream quality via the config.toml file. I initially added this feature for myself, but maybe it could be useful to others as well.

Example config.toml:
```
[mov-cli]
version = 1
debug = false
player = "mpv"
quality = "fhd"  # Preferred quality set to FHD (1080p)
skip_update_checker = false
auto_try_next_scraper = true
hide_ip = true
```

If set to "auto", the highest available quality will be selected, as it was originally intended.
